### PR TITLE
Greatly simplify input checking in IdleState

### DIFF
--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -86,6 +86,11 @@ float Controller::getShoulderPosition(ShoulderName name) const
 	return pos;
 }
 
+sf::Vector2u Controller::getFramesSinceDirectionChange(StickName name) const
+{
+	return stickMap_.at(name).framesSinceChange;
+}
+
 int Controller::getStickAngle(StickName name) const
 {
 	Stick stick = stickMap_.at(name);
@@ -94,11 +99,6 @@ int Controller::getStickAngle(StickName name) const
 	float angle = -atan2f(pos.y, pos.x) * 180 / static_cast<float>(M_PI);
 	// Add 0.5 to fix rounding truncation and add 360 followed by modulo 360 to always get a positive angle
 	return static_cast<int>(angle + 0.5 + 360) % 360;
-}
-
-sf::Vector2u Controller::getFramesSinceDirectionChange(StickName name) const
-{
-	return stickMap_.at(name).framesSinceChange;
 }
 
 bool Controller::buttonPressed(ButtonName name)

--- a/src/Controller.h
+++ b/src/Controller.h
@@ -56,11 +56,11 @@ public:
 	sf::Vector2f getStickPosition(StickName name) const;
 	// Returns a value between 0 and 1
 	float getShoulderPosition(ShoulderName name) const;
-	// Returns the angle of the stick with values between 0 and 360
-	int getStickAngle(StickName name) const;
 	// Returns a 2d vector with frames since a cardinal direction change 
 	// for the x and y position of the stick
 	sf::Vector2u getFramesSinceDirectionChange(StickName name) const;
+	// Returns the angle of the stick with values between 0 and 360
+	int getStickAngle(StickName name) const;
 
 	// Returns true for a given button's initial press and sets it to held, else false
 	bool buttonPressed(ButtonName name);

--- a/src/gamestates/SplashScreen.cpp
+++ b/src/gamestates/SplashScreen.cpp
@@ -60,10 +60,10 @@ void SplashScreen::pollForStart(Game& game)
 			if (sf::Joystick::isButtonPressed(i, 7))
 			{
 				controller = new Controller(i);
-				controller->mapStick(StickName::CONTROL_STICK, sf::Joystick::Axis::X, sf::Joystick::Axis::Y, 80.0, 0.275);
-				controller->mapStick(StickName::C_STICK, sf::Joystick::Axis::V, sf::Joystick::Axis::U, 80.0, 0.275);
-				controller->mapShoulder(ShoulderName::L, sf::Joystick::Axis::Z, -100, 60, 0.3);
-				controller->mapShoulder(ShoulderName::R, sf::Joystick::Axis::R, -100, 60, 0.3);
+				controller->mapStick(StickName::CONTROL_STICK, sf::Joystick::Axis::X, sf::Joystick::Axis::Y, 80.0f, 0.275f);
+				controller->mapStick(StickName::C_STICK, sf::Joystick::Axis::V, sf::Joystick::Axis::U, 80.0f, 0.275f);
+				controller->mapShoulder(ShoulderName::L, sf::Joystick::Axis::Z, -100.0f, 60.0f, 0.3f);
+				controller->mapShoulder(ShoulderName::R, sf::Joystick::Axis::R, -100.0f, 60.0f, 0.3f);
 				controller->mapButton(ButtonName::A, 0);
 				controller->mapButton(ButtonName::B, 1);
 				controller->mapButton(ButtonName::X, 2);
@@ -87,10 +87,10 @@ void SplashScreen::pollForStart(Game& game)
 			if (sf::Joystick::isButtonPressed(i, 7))
 			{
 				controller = new Controller(i);
-				controller->mapStick(StickName::CONTROL_STICK, sf::Joystick::Axis::X, sf::Joystick::Axis::Y, 100.0, 0.275);
-				controller->mapStick(StickName::C_STICK, sf::Joystick::Axis::V, sf::Joystick::Axis::U, 100.0, 0.275);
-				controller->mapShoulder(ShoulderName::L, sf::Joystick::Axis::Z, 0, 60, 0.3);
-				controller->mapShoulder(ShoulderName::R, sf::Joystick::Axis::R, 0, 100, 0.3);
+				controller->mapStick(StickName::CONTROL_STICK, sf::Joystick::Axis::X, sf::Joystick::Axis::Y, 100.0f, 0.275f);
+				controller->mapStick(StickName::C_STICK, sf::Joystick::Axis::V, sf::Joystick::Axis::U, 100.0f, 0.275f);
+				controller->mapShoulder(ShoulderName::L, sf::Joystick::Axis::Z, 0, 60.0f, 0.3f);
+				controller->mapShoulder(ShoulderName::R, sf::Joystick::Axis::R, 0, 100.0f, 0.3f);
 				controller->mapButton(ButtonName::A, 0);
 				controller->mapButton(ButtonName::B, 2);
 				controller->mapButton(ButtonName::X, 1);

--- a/src/playerstates/IdleState.cpp
+++ b/src/playerstates/IdleState.cpp
@@ -39,9 +39,52 @@ void IdleState::handleInput(Player& player, Controller* controller)
 	{
 		return;
 	}
-
+	// Hierarchy of button presses: START->Z->B->L/R->A->X/Y->D_PAD
+	// Z presses
+	if (controller->buttonPressed(ButtonName::Z))
+	{
+		player.setNextState(new GrabState());
+		return;
+	}
+	// B presses
+	else if (controller->buttonPressed(ButtonName::B))
+	{
+		if (controller->getStickPosition(StickName::CONTROL_STICK).x >= 0.60)
+		{
+			if (player.getDirection() == Player::Direction::Left)
+			{
+				player.changeDirection();
+			}
+			player.setNextState(new ForwardSpecialState());
+			return;
+		}
+		else if (controller->getStickPosition(StickName::CONTROL_STICK).x <= -0.60)
+		{
+			if (player.getDirection() == Player::Direction::Right)
+			{
+				player.changeDirection();
+			}
+			player.setNextState(new ForwardSpecialState());
+			return;
+		}
+		else if (controller->getStickPosition(StickName::CONTROL_STICK).y <= -0.55)
+		{
+			std::cout << "up b\n";
+			return;
+		}
+		else if (controller->getStickPosition(StickName::CONTROL_STICK).y >= 0.55)
+		{
+			std::cout << "down b\n";
+			return;
+		}
+		else
+		{
+			std::cout << "neutral b\n";
+			return;
+		}
+	}
 	// L/R presses
-	if (controller->buttonPressed(ButtonName::L) || controller->buttonPressed(ButtonName::R))
+	else if (controller->buttonPressed(ButtonName::L) || controller->buttonPressed(ButtonName::R))
 	{
 		// TODO: Add analog shielding eventually
 		if (controller->buttonPressed(ButtonName::A))
@@ -55,97 +98,12 @@ void IdleState::handleInput(Player& player, Controller* controller)
 			return;
 		}
 	}
-	// B presses
-	else if (controller->buttonPressed(ButtonName::B))
-	{
-		if (controller->getStickPosition(StickName::CONTROL_STICK).y < -0.55 && 
-		Globals::valueBetween(controller->getStickPosition(StickName::CONTROL_STICK).x, -0.55, 0.55) ||
-		controller->getStickPosition(StickName::CONTROL_STICK).y < -0.75 &&
-		Globals::valueBetween(controller->getStickAngle(StickName::CONTROL_STICK), 53, 127))
-		{
-			std::cout << "up b\n";
-			return;
-		}
-		else if (controller->axisPercentageGreaterThan(Axis::Y, 55) && controller->axisPercentageBetween(Axis::X, -55, 55) ||
-			     controller->axisPercentageGreaterThan(Axis::Y, 75) && controller->controlStickAngleBetween(233, 307))
-		{
-			std::cout << "down b\n";
-			return;
-		}
-		else if (controller->axisPercentageGreaterThan(Axis::X, 55))
-		{
-			if (controller->controlStickAngleBetween(0, 54) || controller->controlStickAngleBetween(306, 360))
-			{
-				if (player.getDirection() == Player::Direction::Left)
-				{
-					player.changeDirection();
-				}
-				player.setNextState(new ForwardSpecialState());
-				return;
-			}
-		}
-		else if (controller->axisPercentageLessThan(Axis::X, -55))
-		{
-			if (controller->controlStickAngleBetween(126, 234))
-			{
-				if (player.getDirection() == Player::Direction::Right)
-				{
-					player.changeDirection();
-				}
-				player.setNextState(new ForwardSpecialState());
-				return;
-			}
-		}
-		else
-		{
-			std::cout << "neutral b\n";
-			return;
-		}
-	}
 	// A presses
 	else if (controller->buttonPressed(ButtonName::A))
 	{
-		if (controller->axisPercentageLessThan(Axis::Y, -66))
+		if (controller->getStickPosition(StickName::CONTROL_STICK).x >= 0.80)
 		{
-			if (controller->controlStickAngleBetween(43, 137))
-			{
-				if (controller->cardinalDirectionChange(Axis::Y, 4))
-				{
-					player.setNextState(new UpSmashState());
-					return;
-				}
-				else
-				{
-					if (controller->controlStickAngleBetween(50, 130))
-					{
-						player.setNextState(new UpTiltState());
-						return;
-					}
-				}
-			}
-		}
-		else if (controller->axisPercentageGreaterThan(Axis::Y, 66))
-		{
-			if (controller->controlStickAngleBetween(222, 318))
-			{
-				if (controller->cardinalDirectionChange(Axis::Y, 4))
-				{
-					player.setNextState(new DownSmashState());
-					return;
-				}
-				else
-				{
-					if (controller->controlStickAngleBetween(230, 310))
-					{
-						player.setNextState(new DownTiltState());
-						return;
-					}
-				}
-			}
-		}
-		else if (controller->axisPercentageGreaterThan(Axis::X, 75))
-		{
-			if (controller->controlStickAngleBetween(0, 38) || controller->controlStickAngleBetween(322, 360))
+			if (controller->getFramesSinceDirectionChange(StickName::CONTROL_STICK).x <= 4)
 			{
 				if (player.getDirection() == Player::Direction::Left)
 				{
@@ -155,9 +113,9 @@ void IdleState::handleInput(Player& player, Controller* controller)
 				return;
 			}
 		}
-		else if (controller->axisPercentageLessThan(Axis::X, -75))
+		else if (controller->getStickPosition(StickName::CONTROL_STICK).x <= -0.80)
 		{
-			if (controller->controlStickAngleBetween(142, 218))
+			if (controller->getFramesSinceDirectionChange(StickName::CONTROL_STICK).x <= 4)
 			{
 				if (player.getDirection() == Player::Direction::Right)
 				{
@@ -167,27 +125,56 @@ void IdleState::handleInput(Player& player, Controller* controller)
 				return;
 			}
 		}
-		else if (controller->axisPercentageBetween(Axis::Y, -70, -20))
+		else if (controller->getStickPosition(StickName::CONTROL_STICK).y <= -0.66)
 		{
-			if (controller->controlStickAngleBetween(50, 130))
+			if (controller->getFramesSinceDirectionChange(StickName::CONTROL_STICK).y <= 4)
 			{
-				player.setNextState(new UpTiltState());
+				player.setNextState(new UpSmashState());
 				return;
 			}
 		}
-		else if (controller->axisPercentageBetween(Axis::Y, 20, 70))
+		else if (controller->getStickPosition(StickName::CONTROL_STICK).y >= 0.66)
 		{
-			if (controller->controlStickAngleBetween(230, 310))
+			if (controller->getFramesSinceDirectionChange(StickName::CONTROL_STICK).y <= 4)
 			{
-				player.setNextState(new DownTiltState());
+				player.setNextState(new DownSmashState());
 				return;
 			}
 		}
-		// if none of the above cases, try these
-		if (controller->axisPercentageGreaterThan(Axis::X, 20) && player.getDirection() == Player::Direction::Right ||
-			controller->axisPercentageLessThan(Axis::X, -20) && player.getDirection() == Player::Direction::Left)
+		else if (controller->getStickPosition(StickName::CONTROL_STICK).x > 0)
 		{
-			player.setNextState(new ForwardTiltState());
+			if (player.getDirection == Player::Direction::Right)
+			{
+				player.setNextState(new ForwardTiltState());
+				return;
+			}
+			else
+			{
+				player.setNextState(new JabState());
+				return;
+			}
+		}
+		else if (controller->getStickPosition(StickName::CONTROL_STICK).x < 0)
+		{
+			if (player.getDirection == Player::Direction::Left)
+			{
+				player.setNextState(new ForwardTiltState());
+				return;
+			}
+			else
+			{
+				player.setNextState(new JabState());
+				return;
+			}
+		}
+		else if (controller->getStickPosition(StickName::CONTROL_STICK).y < 0)
+		{
+			player.setNextState(new UpTiltState());
+			return;
+		}
+		else if (controller->getStickPosition(StickName::CONTROL_STICK).y > 0)
+		{
+			player.setNextState(new DownTiltState());
 			return;
 		}
 		else
@@ -202,12 +189,6 @@ void IdleState::handleInput(Player& player, Controller* controller)
 		player.setNextState(new JumpSquatState());
 		return;
 	}
-	// Z presses
-	else if (controller->buttonPressed(ButtonName::Z))
-	{
-		player.setNextState(new GrabState());
-		return;
-	}
 	// D-Pad presses
 	else if (controller->buttonPressed(ButtonName::D_PAD_UP))
 	{
@@ -215,53 +196,80 @@ void IdleState::handleInput(Player& player, Controller* controller)
 		return;
 	}
 	// Control Stick presses
-	else if (controller->axisPercentageLessThan(Axis::Y, -66))
+	else if (controller->getStickPosition(StickName::CONTROL_STICK).y <= -0.66)
 	{
-		if (controller->getControlStickAngle() > 42 && controller->getControlStickAngle() < 138)
+		if (controller->getFramesSinceDirectionChange(StickName::CONTROL_STICK).y <= 4)
 		{
-			if (controller->cardinalDirectionChange(Axis::Y, 4))
-			{
-				player.setNextState(new JumpSquatState());
-				return;
-			}
-		}
-	}
-	else if (controller->axisPercentageGreaterThan(Axis::Y, 66))
-	{
-		if (controller->getControlStickAngle() > 222 && controller->getControlStickAngle() < 318)
-		{
-			player.setNextState(new SquatState());
+			player.setNextState(new JumpSquatState());
 			return;
 		}
 	}
-	else if (controller->axisPercentageGreaterThan(Axis::X, 75))
+	else if (controller->getStickPosition(StickName::CONTROL_STICK).y >= 0.70)
 	{
-		if (controller->getControlStickAngle() >= 0 && controller->getControlStickAngle() < 38 || controller->getControlStickAngle() > 322 && controller->getControlStickAngle() < 360)
+		player.setNextState(new SquatState());
+		return;
+	}
+	else if (controller->getStickPosition(StickName::CONTROL_STICK).x >= 0.80)
+	{
+		if (controller->getFramesSinceDirectionChange(StickName::CONTROL_STICK).x <= 4)
 		{
 			if (player.getDirection() == Player::Direction::Right)
 			{
 				player.setState(new DashState());
 				return;
 			}
+			else
+			{
+				// Smash Turn
+				player.setState(new TurnState());
+				return;
+			}
 		}
 	}
-	else if (controller->axisPercentageLessThan(Axis::X, -75))
+	else if (controller->getStickPosition(StickName::CONTROL_STICK).x <= -0.80)
 	{
-		if (controller->getControlStickAngle() > 142 && controller->getControlStickAngle() < 218)
+		if (controller->getFramesSinceDirectionChange(StickName::CONTROL_STICK).x <= 4)
 		{
 			if (player.getDirection() == Player::Direction::Left)
 			{
 				player.setState(new DashState());
 				return;
 			}
+			else
+			{
+				// Smash Turn
+				player.setState(new TurnState());
+				return;
+			}
 		}
 	}
-	// if none of the above cases, try this
-	if (controller->axisPercentageGreaterThan(Axis::X, 0) && player.getDirection() == Player::Direction::Left ||
-		controller->axisPercentageLessThan(Axis::X, 0) && player.getDirection() == Player::Direction::Right)
+	else if (controller->getStickPosition(StickName::CONTROL_STICK).x > 0)
 	{
-		player.setNextState(new TurnState());
-		return;
+		if (player.getDirection() == Player::Direction::Right)
+		{
+			std::cout << "walk.\n";
+			return;
+		}
+		else
+		{
+			// Smash Turn
+			player.setState(new TurnState());
+			return;
+		}
+	}
+	else if (controller->getStickPosition(StickName::CONTROL_STICK).x < 0)
+	{
+		if (player.getDirection() == Player::Direction::Left)
+		{
+			std::cout << "walk.\n";
+			return;
+		}
+		else
+		{
+			// Smash Turn
+			player.setState(new TurnState());
+			return;
+		}
 	}
 }
 
@@ -305,6 +313,5 @@ void IdleState::animate(Player& player)
 
 void IdleState::destroy(Player& player)
 {
-
 	player.setOnScreenState("");
 }


### PR DESCRIPTION
- Turns out I was overcomplicating the control stick maps.  The radial outwards is due to radius bounds being lower than hardware capabilities thus rounding
- Reduced priority of getStickAngle() in Controller class as it is not as importantly as I originally thought
- Fixed some compiler warnings when initializing controller in SplashScreen
